### PR TITLE
fix: span is missing in multi client request

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ function logHTTPServer(app) {
 }
 
 function logHTTPClient(app) {
-  const httpClientSpan = Symbol('Context#httpClientSpan');
+  const _span = Symbol.for('Request#span');
   app.httpclient.on('request', req => {
     let ctx = req.ctx;
     if (!ctx) {
@@ -67,12 +67,11 @@ function logHTTPClient(app) {
     const span = ctx.tracer.startSpan('http_client');
     span.setTag('span.kind', 'client');
     ctx.tracer.inject(span.context(), 'HTTP', args.headers);
-    ctx[httpClientSpan] = span;
+    req[_span] = span;
   });
 
   app.httpclient.on('response', ({ req, res }) => {
-    const ctx = req.ctx;
-    const span = ctx[httpClientSpan];
+    const span = req[_span];
     const address = req.socket.address();
     span.setTag('peer.hostname', req.options.host);
     span.setTag('peer.port', req.options.port);

--- a/test/fixtures/apps/opentracing-app/app/router.js
+++ b/test/fixtures/apps/opentracing-app/app/router.js
@@ -47,4 +47,12 @@ module.exports = app => {
   app.get('/ctx_curl', async ctx => {
     ctx.body = await ctx.curl('http://www.alibaba.com');
   });
+
+  app.get('/ctx_multi_curl', async ctx => {
+    await Promise.all([
+      ctx.curl('http://www.aliexpress.com'),
+      ctx.curl('http://www.alibaba.com'),
+    ]);
+    ctx.body = 'ok';
+  });
 };

--- a/test/lib/opentracing.test.js
+++ b/test/lib/opentracing.test.js
@@ -176,6 +176,7 @@ describe('test/lib/opentracing.test.js', () => {
         .get('/ctx_curl')
         .expect(200);
 
+      assert(app.config.spans && app.config.spans.length === 2);
       const tags = app.config.spans[0].getTags();
       assert(tags.appname === 'opentracing-test');
       assert(tags['worker.id'] === 0);
@@ -188,6 +189,29 @@ describe('test/lib/opentracing.test.js', () => {
       assert(tags['peer.hostname'] === 'www.alibaba.com');
       assert(tags['peer.port'] === 80);
       assert(/\d+\.\d+\.\d+\.\d+/.test(tags['peer.ipv4']));
+    });
+
+    it('should support multi ctx.curl', async () => {
+      await app.httpRequest()
+        .get('/ctx_multi_curl')
+        .expect(200);
+
+      assert(app.config.spans && app.config.spans.length === 3);
+      let tags = app.config.spans[0].getTags();
+      assert(tags.appname === 'opentracing-test');
+      assert(tags['worker.id'] === 0);
+      assert(tags['process.id'] === process.pid);
+      assert(tags['http.url'] === 'http://www.aliexpress.com/');
+      assert(tags['http.method'] === 'GET');
+      assert(tags['http.status_code'] === 200);
+      assert(tags['http.request_size'] === 0);
+      assert(tags['http.response_size']);
+      assert(tags['peer.hostname'] === 'www.aliexpress.com');
+      assert(tags['peer.port'] === 80);
+      assert(/\d+\.\d+\.\d+\.\d+/.test(tags['peer.ipv4']));
+
+      tags = app.config.spans[1].getTags();
+      assert(tags['http.url'] === 'http://www.alibaba.com/');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

一个 controller 下并行请求多个服务，会被覆盖，理想应该是下面样子，实际上只有一个 child span

![image](https://user-images.githubusercontent.com/1207064/46255601-81d18100-c4d1-11e8-8e86-086d03518cf1.png)

